### PR TITLE
In SetFilter, filterParams.suppressSorting has no effect

### DIFF
--- a/src/setFilter/setFilter.ts
+++ b/src/setFilter/setFilter.ts
@@ -28,7 +28,6 @@ export interface ISetFilterParams extends IFilterParams {
 
 export class SetFilter extends BaseFilter <string, ISetFilterParams, string[]> {
     private model: SetFilterModel;
-    private suppressSorting: boolean;
 
     @QuerySelector('#selectAll')
     private eSelectAll: HTMLInputElement;
@@ -55,7 +54,7 @@ export class SetFilter extends BaseFilter <string, ISetFilterParams, string[]> {
 
         this.virtualList.setComponentCreator(this.createSetListItem.bind(this));
 
-        this.model = new SetFilterModel(this.filterParams.colDef, this.filterParams.rowModel, this.filterParams.valueGetter, this.filterParams.doesRowPassOtherFilter, this.suppressSorting);
+        this.model = new SetFilterModel(this.filterParams.colDef, this.filterParams.rowModel, this.filterParams.valueGetter, this.filterParams.doesRowPassOtherFilter, this.filterParams.suppressSorting);
         this.virtualList.setModel(new ModelWrapper(this.model));
         _.setVisible(<HTMLElement>this.getGui().querySelector('#ag-mini-filter'), !this.filterParams.suppressMiniFilter);
 


### PR DESCRIPTION
The suppressSorting flag in SetFilter's filterParams should suppress sorting of the item list. It does sort them however, even if you pass suppressSorting = true in the filterParams. There is a local variable suppressSorting which is passed (unitialized) to the SetFilterModel instead of filterParams.suppressSorting. This change removes the local variable and uses filterParams.suppressSorting.